### PR TITLE
updated pyinstaller - GHSA-7fcj-pq9j-wh2r

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ click == 7.0
 dynaconf == 2.0.3
 redis == 3.2.1
 eth-account == 0.4.0
-PyInstaller==3.5
+PyInstaller==3.6
 pytest==4.4.1
 pytest-click==0.3


### PR DESCRIPTION
[GHSA-7fcj-pq9j-wh2r](https://github.com/advisories/GHSA-7fcj-pq9j-wh2r)
high severity
Vulnerable versions: < 3.6
Patched version: 3.6
Impact

Local Privilege Escalation in all Windows software frozen by PyInstaller in "onefile" mode.